### PR TITLE
Preprocessor guards for GL version-specific code

### DIFF
--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -16,6 +16,10 @@
 
 #include <nanogui/widget.h>
 
+#if defined(NANOVG_GL2_IMPLEMENTATION) || defined(NANOVG_GLES2_IMPLEMENTATION)
+#define NANOGUI_CURSOR_DISABLED
+#endif
+
 NAMESPACE_BEGIN(nanogui)
 
 /**
@@ -183,8 +187,10 @@ public:
 protected:
     GLFWwindow *mGLFWWindow;
     NVGcontext *mNVGContext;
+#if !defined(NANOGUI_CURSOR_DISABLED)
     GLFWcursor *mCursors[(int) Cursor::CursorCount];
     Cursor mCursor;
+#endif
     std::vector<Widget *> mFocusPath;
     Vector2i mFBSize;
     float mPixelRatio;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -70,10 +70,8 @@ void mainloop(int refresh) {
                 std::chrono::milliseconds time(refresh);
                 while (mainloop_active) {
                     std::this_thread::sleep_for(time);
-#ifndef NANOVG_GLES2_IMPLEMENTATION
-#ifndef NANOVG_GL2_IMPLEMENTATION
+#if !defined(NANOVG_GL2_IMPLEMENTATION) && !defined(NANOVG_GLES2_IMPLEMENTATION)
                     glfwPostEmptyEvent();
-#endif
 #endif
                 }
             }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -70,7 +70,11 @@ void mainloop(int refresh) {
                 std::chrono::milliseconds time(refresh);
                 while (mainloop_active) {
                     std::this_thread::sleep_for(time);
+#ifndef NANOVG_GLES2_IMPLEMENTATION
+#ifndef NANOVG_GL2_IMPLEMENTATION
                     glfwPostEmptyEvent();
+#endif
+#endif
                 }
             }
         );

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -426,7 +426,11 @@ void Screen::drawWidgets() {
 #endif
 
     glViewport(0, 0, mFBSize[0], mFBSize[1]);
+#ifndef NANOVG_GL2_IMPLEMENTATION
+#ifndef NANOVG_GLES2_IMPLEMENTATION
     glBindSampler(0, 0);
+#endif
+#endif
     nvgBeginFrame(mNVGContext, mSize[0], mSize[1], mPixelRatio);
 
     draw(mNVGContext);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -32,7 +32,7 @@
 #endif
 
 /* Allow enforcing the GL2 implementation of NanoVG */
-#define NANOVG_GL3_IMPLEMENTATION
+//#define NANOVG_GL3_IMPLEMENTATION
 #include <nanovg_gl.h>
 
 NAMESPACE_BEGIN(nanogui)

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -42,24 +42,24 @@ static bool gladInitialized = false;
 #endif
 
 inline NVGcontext* nvgCreateContext(int flags) {
-#if defined NANOVG_GL2_IMPLEMENTATION
+#if defined(NANOVG_GL2_IMPLEMENTATION)
   return nvgCreateGL2(flags);
-#elif defined NANOVG_GL3_IMPLEMENTATION
+#elif defined(NANOVG_GL3_IMPLEMENTATION)
   return nvgCreateGL3(flags);
-#elif defined NANOVG_GLES2_IMPLEMENTATION
+#elif defined(NANOVG_GLES2_IMPLEMENTATION)
   return nvgCreateGLES2(flags);
-#elif defined NANOVG_GLES3_IMPLEMENTATION
+#elif defined(NANOVG_GLES3_IMPLEMENTATION)
   return nvgCreateGLES3(flags);
 #endif
 }
 inline void nvgDeleteContext(NVGcontext* ctx) {
-#if defined NANOVG_GL2_IMPLEMENTATION
+#if defined(NANOVG_GL2_IMPLEMENTATION)
   nvgDeleteGL2(ctx);
-#elif defined NANOVG_GL3_IMPLEMENTATION
+#elif defined(NANOVG_GL3_IMPLEMENTATION)
   nvgDeleteGL3(ctx);
-#elif defined NANOVG_GLES2_IMPLEMENTATION
+#elif defined(NANOVG_GLES2_IMPLEMENTATION)
   nvgDeleteGLES2(ctx);
-#elif defined NANOVG_GLES3_IMPLEMENTATION
+#elif defined(NANOVG_GLES3_IMPLEMENTATION)
   nvgDeleteGLES3(ctx);
 #endif
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -43,6 +43,29 @@ std::map<GLFWwindow *, Screen *> __nanogui_screens;
 static bool gladInitialized = false;
 #endif
 
+inline NVGcontext* nvgCreateContext(int flags) {
+#if defined NANOVG_GL2_IMPLEMENTATION
+  return nvgCreateGL2(flags);
+#elif defined NANOVG_GL3_IMPLEMENTATION
+  return nvgCreateGL3(flags);
+#elif defined NANOVG_GLES2_IMPLEMENTATION
+  return nvgCreateGLES2(flags);
+#elif defined NANOVG_GLES3_IMPLEMENTATION
+  return nvgCreateGLES3(flags);
+#endif
+}
+inline void nvgDeleteContext(NVGcontext* ctx) {
+#if defined NANOVG_GL2_IMPLEMENTATION
+  nvgDeleteGL2(ctx);
+#elif defined NANOVG_GL3_IMPLEMENTATION
+  nvgDeleteGL3(ctx);
+#elif defined NANOVG_GLES2_IMPLEMENTATION
+  nvgDeleteGLES2(ctx);
+#elif defined NANOVG_GLES3_IMPLEMENTATION
+  nvgDeleteGLES3(ctx);
+#endif
+}
+
 /* Calculate pixel ratio for hi-dpi devices. */
 static float get_pixel_ratio(GLFWwindow *window) {
 #if defined(_WIN32)
@@ -213,6 +236,8 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
         }
     );
 
+#ifndef NANOVG_GL2_IMPLEMENTATION
+#ifndef NANOVG_GLES2_IMPLEMENTATION
     glfwSetDropCallback(mGLFWWindow,
         [](GLFWwindow *w, int count, const char **filenames) {
             auto it = __nanogui_screens.find(w);
@@ -224,6 +249,8 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
             s->dropCallbackEvent(count, filenames);
         }
     );
+#endif
+#endif
 
     glfwSetScrollCallback(mGLFWWindow,
         [](GLFWwindow *w, double x, double y) {
@@ -295,7 +322,7 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
     flags |= NVG_DEBUG;
 #endif
 
-    mNVGContext = nvgCreateGL3(flags);
+    mNVGContext = nvgCreateContext(flags);
     if (mNVGContext == nullptr)
         throw std::runtime_error("Could not initialize NanoVG!");
 
@@ -319,7 +346,7 @@ Screen::~Screen() {
             glfwDestroyCursor(mCursors[i]);
     }
     if (mNVGContext)
-        nvgDeleteGL3(mNVGContext);
+        nvgDeleteContext(mNVGContext);
     if (mGLFWWindow && mShutdownGLFWOnDestruct)
         glfwDestroyWindow(mGLFWWindow);
 }


### PR DESCRIPTION
When attempting to run NanoGUI under GLES2, a number of GL3 functions were not available. This pull guards against those with preprocessor `#ifdef`s, and removes the hard-coded `#define NANOVG_GL3_IMPLEMENTATION` in `src/screen.cpp`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zooxco/nanogui/1)
<!-- Reviewable:end -->
