### PR TITLE
TOOL-3577: Terminate buffer string to avoid returning uninitialized string data from nanogui::file_dialog()

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -254,6 +254,7 @@ std::string file_dialog(const std::vector<std::pair<std::string, std::string>> &
     return std::string(ofn.lpstrFile);
 #else
     char buffer[FILE_DIALOG_MAX_BUFFER];
+    buffer[0] = '\0';
     std::string cmd = "/usr/bin/zenity --file-selection ";
     if (save)
         cmd += "--save ";


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zooxco/nanogui/3)
<!-- Reviewable:end -->
