### PR TITLE
TOOL-4191: Disable Framebuffer size check when running GL2 and GLES2

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -319,8 +319,11 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
 
     /* Detect framebuffer properties and set up compatible NanoVG context */
     GLint nStencilBits = 0, nSamples = 0;
+
+#if !defined(NANOVG_GL2_IMPLEMENTATION) && !defined(NANOVG_GLES2_IMPLEMENTATION)
     glGetFramebufferAttachmentParameteriv(GL_DRAW_FRAMEBUFFER,
         GL_STENCIL, GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE, &nStencilBits);
+#endif
     glGetIntegerv(GL_SAMPLES, &nSamples);
 
     int flags = 0;


### PR DESCRIPTION
[PROBLEM]
Retrieving the value of GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE is not available in GLES2 or GL2, causing a GL_INVALID_ENUM error.

[SOLUTION]
Disable the `glGetFramebufferAttachmentParameteriv()` call when running on GL2 or GLES2. This will disable the `NVG_STENCIL_STROKES` feature in NanoVG, however this is only a render quality feature and would be incompatible with the OpenGL context in either case.

From the NanoVG Site:

> `NVG_STENCIL_STROKES` means that the render uses better quality rendering for (overlapping) strokes. The quality is mostly visible on wider strokes. If you want speed, you can omit this flag.